### PR TITLE
fixes #20 - literals were being defined as URI by default 

### DIFF
--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepository.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepository.java
@@ -61,13 +61,13 @@ public class MarkLogicRepository extends RepositoryBase implements Repository,Ma
         super();
         this.client = getMarkLogicClient();
         this.f = new ValueFactoryImpl();
-        this.quadMode = false;
+        this.quadMode = true;
         this.auth="DIGEST";
     }
     public MarkLogicRepository(String host, int port, String user, String password, String auth) {
         super();
         this.f = new ValueFactoryImpl();
-        this.quadMode = false;
+        this.quadMode = true;
         this.auth="DIGEST";
         this.host = host;
         this.port = port;
@@ -79,7 +79,7 @@ public class MarkLogicRepository extends RepositoryBase implements Repository,Ma
     public MarkLogicRepository(Object databaseClient) {
         super();
         this.f = new ValueFactoryImpl();
-        this.quadMode = false;
+        this.quadMode = true;
         this.client = new MarkLogicClient(databaseClient);
     }
 

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnection.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnection.java
@@ -74,7 +74,7 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
     public MarkLogicRepositoryConnection(MarkLogicRepository repository, MarkLogicClient client, boolean quadMode) {
         super(repository);
         this.client = client;
-        this.quadMode = quadMode;
+        this.quadMode = true;
         client.setValueFactory(repository.getValueFactory());
     }
 

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/client/MarkLogicClientImpl.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/client/MarkLogicClientImpl.java
@@ -28,9 +28,7 @@ import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.query.RawCombinedQueryDefinition;
 import com.marklogic.client.semantics.*;
-import org.openrdf.model.Resource;
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
+import org.openrdf.model.*;
 import org.openrdf.query.Binding;
 import org.openrdf.repository.sparql.query.SPARQLQueryBindingSet;
 import org.openrdf.rio.RDFFormat;
@@ -259,7 +257,7 @@ public class MarkLogicClientImpl {
         SPARQLQueryDefinition qdef = sparqlManager.newQueryDefinition(sb.toString());
         qdef.withBinding("s", subject.stringValue());
         qdef.withBinding("p", predicate.stringValue());
-        qdef.withBinding("o", object.toString());
+        qdef.withBinding("o", object.stringValue());
         sparqlManager.executeUpdate(qdef, tx);
     }
 

--- a/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnectionTest.java
+++ b/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnectionTest.java
@@ -140,7 +140,7 @@ public class MarkLogicRepositoryConnectionTest extends SesameTestBase {
     public void testSPARQLQuery()
             throws Exception {
 
-        String queryString = "select ?s ?p ?o { ?s ?p ?o } limit 2 ";
+        String queryString = "select * { ?s ?p ?o } limit 2 ";
         TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, queryString);
         TupleQueryResult results = tupleQuery.evaluate();
 
@@ -633,15 +633,15 @@ public class MarkLogicRepositoryConnectionTest extends SesameTestBase {
     @Test
     public void testAddRemoveStatementWithMultipleContext() throws Exception {
 
-        Resource context5 = conn.getValueFactory().createURI("http://marklogic.com/test/context5");
-        Resource context6 = conn.getValueFactory().createURI("http://marklogic.com/test/context6");
+        Resource context5 = conn.getValueFactory().createURI("http://marklogic.com/test/context7");
+        Resource context6 = conn.getValueFactory().createURI("http://marklogic.com/test/context8");
 
         URI alice = conn.getValueFactory().createURI("http://example.org/people/alice");
         URI bob = conn.getValueFactory().createURI("http://example.org/people/bob");
         URI name = conn.getValueFactory().createURI("http://example.org/ontology/name");
         URI person = conn.getValueFactory().createURI("http://example.org/ontology/Person");
-        Literal bobsName = conn.getValueFactory().createLiteral("Bob");
-        Literal alicesName = conn.getValueFactory().createLiteral("Alice");
+        Literal bobsName = conn.getValueFactory().createLiteral("Bob","http://www.w3.org/2001/XMLSchema#string");
+        Literal alicesName = conn.getValueFactory().createLiteral("Alice","http://www.w3.org/2001/XMLSchema#string");
 
         conn.add(alice, RDF.TYPE, person, context5);
         conn.add(alice, name, alicesName,context5, context6);
@@ -652,6 +652,8 @@ public class MarkLogicRepositoryConnectionTest extends SesameTestBase {
         conn.remove(alice, name, alicesName, context5, context6);
         conn.remove(bob, RDF.TYPE, person, context5);
         conn.remove(bob, name, bobsName, context5, context6);
+
+        conn.clear(context5,context6);
     }
 
     @Test
@@ -740,8 +742,8 @@ public class MarkLogicRepositoryConnectionTest extends SesameTestBase {
         URI bob = conn.getValueFactory().createURI("http://example.org/people/bob");
         URI name = conn.getValueFactory().createURI("http://example.org/ontology/name");
         URI person = conn.getValueFactory().createURI("http://example.org/ontology/Person");
-        Literal bobsName = conn.getValueFactory().createLiteral("Bob");
-        Literal alicesName = conn.getValueFactory().createLiteral("Alice");
+        Literal bobsName = conn.getValueFactory().createLiteral("Bob","http://www.w3.org/2001/XMLSchema#string");
+        Literal alicesName = conn.getValueFactory().createLiteral("Alice","http://www.w3.org/2001/XMLSchema#string");
 
         conn.add(alice, RDF.TYPE, person, context5);
         conn.add(alice, name, alicesName,context5, context6);


### PR DESCRIPTION
Sesame gets confused when defining a literal, explicitly stating fixes this, as example below illustrates;

Literal alicesName = conn.getValueFactory().createLiteral("Alice","http://www.w3.org/2001/XMLSchema#string");
