### PR TITLE
reverted back to multiple interfaces

### DIFF
--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnection.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnection.java
@@ -54,7 +54,7 @@ import static org.openrdf.query.QueryLanguage.SPARQL;
  *
  * @author James Fuller
  */
-public class MarkLogicRepositoryConnection extends RepositoryConnectionBase implements MarkLogicRepositoryConnectionDependent {
+public class MarkLogicRepositoryConnection extends RepositoryConnectionBase implements RepositoryConnection,MarkLogicRepositoryConnectionDependent {
 
     protected final Logger logger = LoggerFactory.getLogger(MarkLogicRepositoryConnection.class);
 

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnectionDependent.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnectionDependent.java
@@ -20,10 +20,9 @@
 package com.marklogic.semantics.sesame;
 
 import org.openrdf.query.*;
-import org.openrdf.repository.RepositoryConnection;
 import org.openrdf.repository.RepositoryException;
 
-public interface MarkLogicRepositoryConnectionDependent extends RepositoryConnection {
+public interface MarkLogicRepositoryConnectionDependent {
 
     public Query prepareQuery(String queryString) throws RepositoryException, MalformedQueryException;
     public TupleQuery prepareTupleQuery(String queryString) throws RepositoryException, MalformedQueryException;

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicQuery.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicQuery.java
@@ -24,6 +24,7 @@ import com.marklogic.semantics.sesame.client.MarkLogicClientDependent;
 import org.openrdf.model.Value;
 import org.openrdf.model.impl.ValueFactoryImpl;
 import org.openrdf.query.Dataset;
+import org.openrdf.query.Query;
 import org.openrdf.query.QueryLanguage;
 import org.openrdf.query.impl.AbstractQuery;
 import org.openrdf.repository.sparql.query.QueryStringUtil;
@@ -35,7 +36,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author James Fuller
  */
-public class MarkLogicQuery extends AbstractQuery implements MarkLogicClientDependent,MarkLogicQueryDependent {
+public class MarkLogicQuery extends AbstractQuery implements Query,MarkLogicClientDependent,MarkLogicQueryDependent {
 
     protected final Logger logger = LoggerFactory.getLogger(MarkLogicQuery.class);
 

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicQueryDependent.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicQueryDependent.java
@@ -19,13 +19,11 @@
  */
 package com.marklogic.semantics.sesame.query;
 
-import org.openrdf.query.Query;
-
 /**
  *
  * @author James Fuller
  */
-public interface MarkLogicQueryDependent extends Query {
+public interface MarkLogicQueryDependent {
 
     Object getRulesets();
     void setRulesets(Object rulesets);


### PR DESCRIPTION
extending an interface requires recompilaton when (if) they change, multiple interfaces seems to be more developer friendly and easier to maintain through time.
