### PR TITLE
fix for #70 - inputstream variant

### DIFF
--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/client/MarkLogicClientImpl.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/client/MarkLogicClientImpl.java
@@ -255,12 +255,12 @@ public class MarkLogicClientImpl {
                 graphManager.mergeGraphs(new FileHandle(file));
             } else {
                 //TBD- must be more efficient
-                if (contexts.length != 0) {
+                if (notNull(contexts) && contexts.length>0) {
                     for (Resource context : contexts) {
                         graphManager.merge(context.toString(), new FileHandle(file), tx);
                     }
                 } else {
-                    graphManager.merge(null, new FileHandle(file), tx);
+                    graphManager.merge(DEFAULT_GRAPH_URI, new FileHandle(file), tx);
                 }
             }
         } catch (FailedRequestException e) {
@@ -276,10 +276,10 @@ public class MarkLogicClientImpl {
             graphManager.mergeGraphs(new InputStreamHandle(in));
         } else {
             //TBD- must be more efficient
-            if (contexts.length != 0) {
+            if (notNull(contexts) && contexts.length>0) {
                 graphManager.merge(contexts[0].stringValue(), new InputStreamHandle(in), tx);
             } else {
-                graphManager.merge(null, new InputStreamHandle(in), tx);
+                graphManager.merge(DEFAULT_GRAPH_URI, new InputStreamHandle(in), tx);
             }
         }
     }

--- a/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnectionTest.java
+++ b/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnectionTest.java
@@ -146,6 +146,15 @@ public class MarkLogicRepositoryConnectionTest extends SesameTestBase {
         conn.clear(context1, context2);
     }
 
+    // https://github.com/marklogic/marklogic-sesame/issues/70
+    @Test
+    public void testAddTurtleWithNullContext() throws Exception {
+        File inputFile = new File("src/test/resources/testdata/default-graph-1.ttl");
+        conn.add(inputFile, "http://example.org/example1/", RDFFormat.TURTLE, null);
+        Assert.assertEquals(4,conn.size(null));
+        conn.clear(null);
+    }
+
     // https://github.com/marklogic/marklogic-sesame/issues/65
     @Test
     public void testAddMalformedTurtle() throws Exception {


### PR DESCRIPTION
added 

```
    @Test
    public void testAddTurtleWithNullContext() throws Exception {
        File inputFile = new File("src/test/resources/testdata/default-graph-1.ttl");
        conn.add(inputFile, "http://example.org/example1/", RDFFormat.TURTLE, null);
        Assert.assertEquals(4,conn.size(null));
        conn.clear(null);
    }
```