### PR TITLE
fix for #122

### DIFF
--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnection.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnection.java
@@ -75,6 +75,8 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
 
     private MarkLogicClient client;
 
+    private Object graphPerms;
+
     /**
      * constructor
      *
@@ -252,7 +254,7 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
     @Override
     public MarkLogicTupleQuery prepareTupleQuery(QueryLanguage queryLanguage, String queryString, String baseURI) throws RepositoryException, MalformedQueryException {
         if (QueryLanguage.SPARQL.equals(queryLanguage)) {
-            return new MarkLogicTupleQuery(this.client, new SPARQLQueryBindingSet(), baseURI, queryString);
+            return new MarkLogicTupleQuery(this.client, new SPARQLQueryBindingSet(), baseURI, queryString, graphPerms);
         }
         throw new UnsupportedQueryLanguageException("Unsupported query language " + queryLanguage.getName());
     }
@@ -313,7 +315,7 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
             throws RepositoryException, MalformedQueryException
     {
         if (QueryLanguage.SPARQL.equals(queryLanguage)) {
-            return new MarkLogicGraphQuery(this.client, new SPARQLQueryBindingSet(), baseURI, queryString);
+            return new MarkLogicGraphQuery(this.client, new SPARQLQueryBindingSet(), baseURI, queryString, graphPerms);
         }
         throw new UnsupportedQueryLanguageException("Unsupported query language " + queryLanguage.getName());
     }
@@ -372,7 +374,7 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
     @Override
     public MarkLogicBooleanQuery prepareBooleanQuery(QueryLanguage queryLanguage, String queryString, String baseURI) throws RepositoryException, MalformedQueryException {
         if (QueryLanguage.SPARQL.equals(queryLanguage)) {
-            return new MarkLogicBooleanQuery(this.client, new SPARQLQueryBindingSet(), baseURI, queryString);
+            return new MarkLogicBooleanQuery(this.client, new SPARQLQueryBindingSet(), baseURI, queryString, graphPerms);
         }
         throw new UnsupportedQueryLanguageException("Unsupported query language " + queryLanguage.getName());
     }
@@ -431,7 +433,7 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
     @Override
     public MarkLogicUpdateQuery prepareUpdate(QueryLanguage queryLanguage, String queryString, String baseURI) throws RepositoryException, MalformedQueryException {
         if (QueryLanguage.SPARQL.equals(queryLanguage)) {
-            return new MarkLogicUpdateQuery(this.client, new SPARQLQueryBindingSet(), baseURI, queryString);
+            return new MarkLogicUpdateQuery(this.client, new SPARQLQueryBindingSet(), baseURI, queryString, graphPerms);
         }
         throw new UnsupportedQueryLanguageException("Unsupported query language " + queryLanguage.getName());
     }
@@ -1285,6 +1287,26 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
     }
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
+
+    /**
+     * sets default graph permissions to be used by all queries
+     *
+     * @param graphPerms
+     */
+    @Override
+    public void setGraphPerms(Object graphPerms) {
+        this.graphPerms = graphPerms;
+    }
+
+    /**
+     * returns default graph permissions to be used by all queries
+     *
+     * @return GraphPermissions
+     */
+    @Override
+    public Object getGraphPerms() {
+        return this.graphPerms;
+    }
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnectionDependent.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnectionDependent.java
@@ -48,4 +48,8 @@ public interface MarkLogicRepositoryConnectionDependent {
 
     void remove(Iterable<? extends Statement> statements) throws RepositoryException;
     <E extends Exception> void remove(Iteration<? extends Statement, E> statements) throws RepositoryException, E;
+
+    void setGraphPerms(Object graphPerms);
+    Object getGraphPerms();
+
 }

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicBooleanQuery.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicBooleanQuery.java
@@ -48,8 +48,8 @@ public class MarkLogicBooleanQuery extends MarkLogicQuery implements BooleanQuer
      * @param baseUri
      * @param queryString
      */
-    public MarkLogicBooleanQuery(MarkLogicClient client, SPARQLQueryBindingSet bindingSet, String baseUri, String queryString) {
-        super(client, bindingSet, baseUri, queryString);
+    public MarkLogicBooleanQuery(MarkLogicClient client, SPARQLQueryBindingSet bindingSet, String baseUri, String queryString, Object graphPerms) {
+        super(client, bindingSet, baseUri, queryString, graphPerms);
     }
 
     /**

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicGraphQuery.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicGraphQuery.java
@@ -49,8 +49,8 @@ public class MarkLogicGraphQuery extends MarkLogicQuery implements GraphQuery,Ma
      * @param baseUri
      * @param queryString
      */
-    public MarkLogicGraphQuery(MarkLogicClient client, SPARQLQueryBindingSet bindingSet, String baseUri, String queryString) {
-        super(client, bindingSet, baseUri, queryString);
+    public MarkLogicGraphQuery(MarkLogicClient client, SPARQLQueryBindingSet bindingSet, String baseUri, String queryString, Object graphPerms) {
+        super(client, bindingSet, baseUri, queryString, graphPerms);
     }
 
     /**

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicQuery.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicQuery.java
@@ -59,13 +59,14 @@ public class MarkLogicQuery extends AbstractQuery implements Query,MarkLogicClie
      * @param baseUri
      * @param queryString
      */
-    public MarkLogicQuery(MarkLogicClient client, SPARQLQueryBindingSet bindingSet, String baseUri, String queryString) {
+    public MarkLogicQuery(MarkLogicClient client, SPARQLQueryBindingSet bindingSet, String baseUri, String queryString, Object graphPerms) {
         super();
         setBaseURI(baseUri);
         setQueryString(queryString);
         setMarkLogicClient(client);
         setBindings(bindingSet);
         setIncludeInferred(true); // is default set true
+        setGraphPerms(graphPerms);
     }
 
     /**

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicTupleQuery.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicTupleQuery.java
@@ -49,8 +49,8 @@ public class MarkLogicTupleQuery extends MarkLogicQuery implements TupleQuery,Ma
      * @param baseUri
      * @param queryString
      */
-    public MarkLogicTupleQuery(MarkLogicClient client, SPARQLQueryBindingSet bindingSet, String baseUri, String queryString) {
-        super(client, bindingSet, baseUri, queryString);
+    public MarkLogicTupleQuery(MarkLogicClient client, SPARQLQueryBindingSet bindingSet, String baseUri, String queryString, Object graphPerms) {
+        super(client, bindingSet, baseUri, queryString, graphPerms);
     }
 
     /**

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicUpdateQuery.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicUpdateQuery.java
@@ -49,8 +49,8 @@ public class MarkLogicUpdateQuery extends MarkLogicQuery implements Update,MarkL
      * @param baseUri
      * @param queryString
      */
-    public MarkLogicUpdateQuery(MarkLogicClient client, SPARQLQueryBindingSet bindingSet, String baseUri, String queryString) {
-        super(client, bindingSet, baseUri, queryString);
+    public MarkLogicUpdateQuery(MarkLogicClient client, SPARQLQueryBindingSet bindingSet, String baseUri, String queryString, Object graphPerms) {
+        super(client, bindingSet, baseUri, queryString,graphPerms);
     }
 
     /**

--- a/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/MarkLogicGraphPermsTest.java
+++ b/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/MarkLogicGraphPermsTest.java
@@ -114,6 +114,28 @@ public class MarkLogicGraphPermsTest extends SesameTestBase {
         conn.clear(context);
     }
 
+    // https://github.com/marklogic/marklogic-sesame/issues/122
+    @Test
+    public void testUpdateQueryWithPermsFromConnectionDefaults()
+            throws Exception {
+
+        GraphManager gmgr = adminClient.newGraphManager();
+        conn.setGraphPerms(gmgr.permission("app-user", Capability.READ));
+
+        Resource context = conn.getValueFactory().createURI("http://marklogic.com/test/graph/permstest");
+
+        String defGraphQuery = "INSERT DATA { GRAPH <http://marklogic.com/test/graph/permstest> { <http://marklogic.com/test> <pp1> <oo1> } }";
+        String checkQuery = "ASK WHERE {  GRAPH <http://marklogic.com/test/graph/permstest> {<http://marklogic.com/test> <pp1> <oo1> }}";
+        MarkLogicUpdateQuery updateQuery = conn.prepareUpdate(QueryLanguage.SPARQL, defGraphQuery);
+        updateQuery.execute();
+
+        BooleanQuery booleanQuery = conn.prepareBooleanQuery(QueryLanguage.SPARQL, checkQuery);
+        boolean results = booleanQuery.evaluate();
+        Assert.assertEquals(true, results);
+
+        conn.clear(context);
+    }
+
     @Ignore
     public void testGetGraphPermsofResult(){
 

--- a/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/query/MarkLogicTupleQueryTest.java
+++ b/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/query/MarkLogicTupleQueryTest.java
@@ -15,14 +15,14 @@
  */
 package com.marklogic.semantics.sesame.query;
 
+import com.marklogic.client.io.FileHandle;
+import com.marklogic.client.semantics.GraphManager;
+import com.marklogic.client.semantics.RDFMimeTypes;
+import com.marklogic.client.semantics.SPARQLRuleset;
+import com.marklogic.semantics.sesame.MarkLogicRepositoryConnection;
+import com.marklogic.semantics.sesame.SesameTestBase;
 import info.aduna.iteration.ConvertingIteration;
 import info.aduna.iteration.ExceptionConvertingIteration;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.util.List;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -31,27 +31,17 @@ import org.openrdf.model.Resource;
 import org.openrdf.model.Value;
 import org.openrdf.model.ValueFactory;
 import org.openrdf.model.impl.ValueFactoryImpl;
-import org.openrdf.query.BindingSet;
-import org.openrdf.query.MalformedQueryException;
-import org.openrdf.query.Query;
-import org.openrdf.query.QueryEvaluationException;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.QueryResultHandlerException;
-import org.openrdf.query.TupleQuery;
-import org.openrdf.query.TupleQueryResult;
-import org.openrdf.query.TupleQueryResultHandler;
+import org.openrdf.query.*;
 import org.openrdf.query.resultio.sparqlxml.SPARQLResultsXMLWriter;
 import org.openrdf.repository.RepositoryException;
 import org.openrdf.repository.RepositoryResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.semantics.GraphManager;
-import com.marklogic.client.semantics.RDFMimeTypes;
-import com.marklogic.client.semantics.SPARQLRuleset;
-import com.marklogic.semantics.sesame.MarkLogicRepositoryConnection;
-import com.marklogic.semantics.sesame.SesameTestBase;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.List;
 
 /**
  * Created by jfuller on 8/11/15.


### PR DESCRIPTION
this PR enables setting of RepositoryConnection level graph permissions, which are then used as defaults whenever a query of any type is instantiated.

```
        GraphManager gmgr = adminClient.newGraphManager();
        conn.setGraphPerms(gmgr.permission("app-user", Capability.READ));
```