### PR TITLE
fix for #138

### DIFF
--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnection.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnection.java
@@ -641,7 +641,7 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
     @Override
     public boolean hasStatement(Resource subject, URI predicate, Value object, boolean includeInferred, Resource... contexts) throws RepositoryException {
         String queryString = null;
-        if (contexts.length == 0) {
+        if (contexts == null || contexts.length == 0) {
             queryString = SOMETHING;
         }
         else {

--- a/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnectionTest.java
+++ b/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnectionTest.java
@@ -614,6 +614,7 @@ public class MarkLogicRepositoryConnectionTest extends SesameTestBase {
         conn.clear(context1);
     }
 
+    // https://github.com/marklogic/marklogic-sesame/issues/138
     @Test
     public void testHasStatement() throws Exception
     {
@@ -628,6 +629,7 @@ public class MarkLogicRepositoryConnectionTest extends SesameTestBase {
 
         Assert.assertTrue(conn.hasStatement(st1, false, context1));
         Assert.assertTrue(conn.hasStatement(st1, false, context1, null));
+        Assert.assertTrue(conn.hasStatement(st1, false,null));
         Assert.assertFalse(conn.hasStatement(st1, false, (Resource) null));
         Assert.assertTrue(conn.hasStatement(st1, false));
         Assert.assertTrue(conn.hasStatement(null, null, null, false));


### PR DESCRIPTION
when hasStatement defines a single context as null, it no longer throws null pointer exception

```
        Assert.assertTrue(conn.hasStatement(st1, false,null));
```