### PR TITLE
simple enhancment for init GraphPerms with empty()

### DIFF
--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnection.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnection.java
@@ -95,6 +95,7 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
         super(repository);
         this.client = client;
         this.quadMode = true;
+        this.defaultGraphPerms = client.emptyGraphPerms();
         setIsolationLevel(IsolationLevels.SNAPSHOT);
         client.setValueFactory(repository.getValueFactory());
         client.initTimer();

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/client/MarkLogicClient.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/client/MarkLogicClient.java
@@ -495,6 +495,9 @@ public class MarkLogicClient {
         return getClient().getGraphPerms();
     }
 
+	public GraphPermissions emptyGraphPerms(){
+		return _client.getDatabaseClient().newGraphManager().newGraphPermissions();
+	}
 
 	/**
 	 *exec

--- a/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/MarkLogicGraphPermsTest.java
+++ b/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/MarkLogicGraphPermsTest.java
@@ -123,8 +123,11 @@ public class MarkLogicGraphPermsTest extends SesameTestBase {
     public void testUpdateQueryWithPermsFromConnectionDefaults()
             throws Exception {
 
+        GraphPermissions gp = conn.getDefaultGraphPerms();
+        Assert.assertEquals(0,gp.size());
         GraphManager gmgr = adminClient.newGraphManager();
         conn.setDefaultGraphPerms(gmgr.permission("app-user", Capability.READ));
+
 
         Resource context = conn.getValueFactory().createURI("http://marklogic.com/test/graph/permstest");
 


### PR DESCRIPTION
leverages change to java api client ... all tests green, no blast radius.