### PR TITLE
bump sesame dep to Sesame 2.8.7

### DIFF
--- a/marklogic-sesame-performance/build.gradle
+++ b/marklogic-sesame-performance/build.gradle
@@ -30,7 +30,7 @@ repositories {
 }
 
 dependencies {
-    compile('org.openrdf.sesame:sesame-runtime:2.8.6')
+    compile('org.openrdf.sesame:sesame-runtime:2.8.7')
 
     compile('com.marklogic:java-client-api:3.0-SNAPSHOT') {
         exclude(group: 'org.slf4j')

--- a/marklogic-sesame/build.gradle
+++ b/marklogic-sesame/build.gradle
@@ -30,7 +30,7 @@ repositories {
 }
 
 dependencies {
-    compile('org.openrdf.sesame:sesame-runtime:2.8.6')
+    compile('org.openrdf.sesame:sesame-runtime:2.8.7')
 
     compile('com.marklogic:java-client-api:3.0-SNAPSHOT') {
         exclude(group: 'org.slf4j')


### PR DESCRIPTION
#218 verified that marklogic-sesame works with 2.8.7 though will be leaving this as a PR for the time being.