### PR TITLE
build against 2.8.9 and minor amends to deps

### DIFF
--- a/marklogic-sesame-performance/build.gradle
+++ b/marklogic-sesame-performance/build.gradle
@@ -31,10 +31,6 @@ repositories {
 dependencies {
     compile('org.openrdf.sesame:sesame-runtime:2.8.7')
 
-    compile('com.marklogic:java-client-api:3.0-SNAPSHOT') {
-        exclude(group: 'org.slf4j')
-        exclude(group: 'ch.qos.logback')
-    }
     compile('com.marklogic:marklogic-sesame:1.0.0-SNAPSHOT')
 
     compile('org.slf4j:slf4j-api:1.7.10')

--- a/marklogic-sesame/build.gradle
+++ b/marklogic-sesame/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
-    compile('org.openrdf.sesame:sesame-runtime:2.8.7')
+    compile('org.openrdf.sesame:sesame-runtime:2.8.9')
 
     // for the bleeding edge switch to com.marklogic:java-client-api:4.0-SNAPSHOT
     compile('com.marklogic:java-client-api:3.0.4') {

--- a/marklogic-sesame/build.gradle
+++ b/marklogic-sesame/build.gradle
@@ -33,7 +33,8 @@ repositories {
 dependencies {
     compile('org.openrdf.sesame:sesame-runtime:2.8.7')
 
-    compile('com.marklogic:java-client-api:3.0-SNAPSHOT') {
+    // for the bleeding edge switch to com.marklogic:java-client-api:4.0-SNAPSHOT
+    compile('com.marklogic:java-client-api:3.0.4') {
         exclude(group: 'org.slf4j')
         exclude(group: 'ch.qos.logback')
     }

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnection.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnection.java
@@ -139,16 +139,18 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
         throws RepositoryException
     {
         try {
-            sync();
-            if (this.isActive()) {
-                logger.debug("rollback open transaction on closing connection.");
-                client.rollbackTransaction();
+            if(this.isOpen()){
+                sync();
+                if (this.isActive()) {
+                    logger.debug("rollback open transaction on closing connection.");
+                    client.rollbackTransaction();
+                }
+                super.close();
+                client.stopTimer();
             }
         } catch (Exception e) {
-            
+            throw new RepositoryException("Unable to close connection.");
         }
-        client.stopTimer();
-        super.close();
     }
     
     /**

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/client/MarkLogicClient.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/client/MarkLogicClient.java
@@ -108,9 +108,9 @@ public class MarkLogicClient {
      */
 	public void initTimer(){
         if(this.WRITE_CACHE_ENABLED) {
-            this.cache = new WriteCacheTimerTask(this);
-            this.timer = new Timer();
-            this.timer.scheduleAtFixedRate(cache, WriteCacheTimerTask.DEFAULT_INITIAL_DELAY, WriteCacheTimerTask.DEFAULT_CACHE_MILLIS);
+            cache = new WriteCacheTimerTask(this);
+            timer = new Timer();
+            timer.scheduleAtFixedRate(cache, WriteCacheTimerTask.DEFAULT_INITIAL_DELAY, WriteCacheTimerTask.DEFAULT_CACHE_MILLIS);
         }
     }
 
@@ -119,8 +119,12 @@ public class MarkLogicClient {
      */
 	public void stopTimer() {
         if(this.WRITE_CACHE_ENABLED) {
-            cache.cancel();
-            timer.cancel();
+			if(cache != null) {
+				cache.cancel();
+			}
+            if(timer != null){
+				timer.cancel();
+			}
         }
     }
 
@@ -130,7 +134,7 @@ public class MarkLogicClient {
      * @throws MarkLogicSesameException
      */
     public void sync() throws MarkLogicSesameException {
-        if(WRITE_CACHE_ENABLED) cache.forceRun();
+        if(WRITE_CACHE_ENABLED && cache != null) cache.forceRun();
     }
 
 	/**

--- a/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/SPARQLRepositoryTest.java
+++ b/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/SPARQLRepositoryTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015-2016 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * A library that enables access to a MarkLogic-backed triple-store via the
+ * Sesame API.
+ */
+package com.marklogic.semantics.sesame;
+
+import org.junit.*;
+import org.junit.rules.ExpectedException;
+import org.openrdf.model.ValueFactory;
+import org.openrdf.repository.sparql.SPARQLConnection;
+import org.openrdf.repository.sparql.SPARQLRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * test connectivity to SPARQLRepository with v1/graphs/sparql
+ *
+ * @author James Fuller
+ */
+public class SPARQLRepositoryTest extends SesameTestBase {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    protected SPARQLRepository sr;
+    protected SPARQLConnection conn;
+    protected ValueFactory f;
+
+    @Before
+    public void setUp()
+            throws Exception {
+        logger.debug("setting up test");
+        SPARQLRepository sr = new SPARQLRepository("http://localhost:8200/v1/graphs/sparql");
+        sr.setUsernameAndPassword("admin","admin");
+        sr.initialize();
+        f = sr.getValueFactory();
+        conn = (SPARQLConnection) sr.getConnection();
+        logger.info("test setup complete.");
+    }
+
+    @After
+    public void tearDown()
+            throws Exception {
+        logger.debug("tearing down...");
+        if(conn.isActive() && conn.isOpen()){conn.rollback();}
+        if(conn.isOpen()){conn.clear();}
+        conn.close();
+        conn = null;
+        rep.shutDown();
+        rep = null;
+        logger.info("tearDown complete.");
+    }
+
+    // https://github.com/marklogic/marklogic-sesame/issues/237
+    @Test
+    @Ignore
+    public void testSPARQLRepositoryWithMarkLogic()
+            throws Exception
+    {
+        Assert.assertEquals(0, conn.size());
+    }
+}


### PR DESCRIPTION
a grab bag of minor updates:

* bound to java api client 3.0.4 from maven
* upgrade to Sesame 2.8.9 (all tests green) #239 
* some minor tweaks (inspired by recent commit in marklogic-jena)
* added a test for SPARQLRepository (unrelated to marklogic-sesame but we need the test) #237

this patch precedes a largish patch based on sonar suggestions and some general housecleaning.
