### PR TITLE
IO CLOSE_WAIT test case

### DIFF
--- a/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/SesameTestBase.java
+++ b/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/SesameTestBase.java
@@ -18,6 +18,7 @@ package com.marklogic.semantics.sesame;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.io.StringHandle;
+
 import org.junit.After;
 import org.junit.AfterClass;
 
@@ -96,6 +97,13 @@ public class SesameTestBase {
         adminClient.release();
         writerClient.release();
         readerClient.release();
+        System.out.println("just waiting now before shutting down JVM");
+        try {
+			Thread.sleep(30000);
+		} catch (InterruptedException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}        
     }
 }
 


### PR DESCRIPTION
extended test case to show the TCP CLOSE_WAIT connections hanging around even after the MarkLogicTupleQuery executes the underlying sparql queries and parses the results. Refer to testSPARQLQueryWithPagination this has a loop and a sleep in finally after closing all the connections.

to monitor the TCP connections lurking around even after the connection has closed I have added a sleep, this basically replicates the TOMCAT JVM problem we see in customers UAT environment, where JVM is not shutdown and slowly these TCP connections keep building.

 finally {
    conn.close();
    Thread.sleep(60000);        
}

To monitor the TCP connection you can use the following command.
netstat -an | grep 8200 | grep CLOSE_WAIT
