### PR TITLE
#321,#308 - refactored write cache, re-organise sync() calls

### DIFF
--- a/marklogic-sesame-functionaltests/src/test/java/com/marklogic/sesame/functionaltests/util/ConnectedRESTQA.java
+++ b/marklogic-sesame-functionaltests/src/test/java/com/marklogic/sesame/functionaltests/util/ConnectedRESTQA.java
@@ -708,7 +708,7 @@ public abstract class ConnectedRESTQA {
 		try{
 			DefaultHttpClient client = new DefaultHttpClient();
 			client.getCredentialsProvider().setCredentials(
-					new AuthScope("localhost", 8002),
+					new AuthScope( "localhost", 8002),
 					new UsernamePasswordCredentials("admin", "admin"));
 			HttpGet get = new HttpGet("http://localhost:8002"+ "/manage/v2/hosts?format=json");
 			

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnection.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnection.java
@@ -672,7 +672,7 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
         }
         try {
             logger.debug(queryString);
-            BooleanQuery query = prepareBooleanQuery(queryString); // baseuri ?
+            MarkLogicBooleanQuery query = prepareBooleanQuery(queryString); // baseuri ?
 
             setBindings(query, subject, predicate, object, contexts);
             return query.evaluate();
@@ -779,7 +779,6 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
      */
     @Override
     public long size() throws RepositoryException{
-        sync();
         try {
             MarkLogicTupleQuery tupleQuery = prepareTupleQuery(COUNT_EVERYTHING);
             tupleQuery.setIncludeInferred(false);
@@ -804,7 +803,6 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
      */
     @Override
     public long size(Resource... contexts) throws RepositoryException {
-        sync();
         if (contexts == null) {
             contexts = new Resource[] { null };
         }
@@ -1130,7 +1128,6 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
      */
     @Override
     public void remove(Iterable<? extends Statement> statements) throws RepositoryException {
-        sync();
         Iterator <? extends Statement> iter = statements.iterator();
         while(iter.hasNext()){
             Statement st = iter.next();
@@ -1147,7 +1144,6 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
      */
     @Override
     public void remove(Iterable<? extends Statement> statements, Resource... contexts) throws RepositoryException {
-        sync();
         Iterator <? extends Statement> iter = statements.iterator();
         while(iter.hasNext()){
             Statement st = iter.next();
@@ -1165,7 +1161,6 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
      */
     @Override
     public <E extends Exception> void remove(Iteration<? extends Statement, E> statements) throws RepositoryException, E {
-        sync();
         while(statements.hasNext()){
             Statement st = statements.next();
             getClient().sendRemove(null, st.getSubject(), st.getPredicate(), st.getObject());
@@ -1183,7 +1178,6 @@ public class MarkLogicRepositoryConnection extends RepositoryConnectionBase impl
      */
     @Override
     public <E extends Exception> void remove(Iteration<? extends Statement, E> statements, Resource... contexts) throws RepositoryException, E {
-        sync();
         while(statements.hasNext()){
             Statement st = statements.next();
             getClient().sendRemove(null, st.getSubject(), st.getPredicate(), st.getObject(), mergeResource(st.getContext(), contexts));

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/client/TripleCache.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/client/TripleCache.java
@@ -25,6 +25,9 @@ import org.openrdf.model.Resource;
 import org.openrdf.model.URI;
 import org.openrdf.model.Value;
 import org.openrdf.model.impl.LinkedHashModel;
+import org.openrdf.query.MalformedQueryException;
+import org.openrdf.query.UpdateExecutionException;
+import org.openrdf.repository.RepositoryException;
 import org.openrdf.rio.RDFFormat;
 import org.openrdf.rio.RDFHandlerException;
 import org.openrdf.rio.RDFParseException;
@@ -35,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
+import java.io.IOException;
 import java.util.Date;
 import java.util.TimerTask;
 
@@ -43,32 +47,32 @@ import java.util.TimerTask;
  *
  * @author James Fuller
  */
-public class WriteCacheTimerTask extends TimerTask {
+public abstract class TripleCache extends TimerTask {
 
-    private static final Logger log = LoggerFactory.getLogger(WriteCacheTimerTask.class);
+    private static final Logger log = LoggerFactory.getLogger(TripleCache.class);
 
-    private Model cache;
-    private MarkLogicClient client;
+    protected Model cache;
+    protected MarkLogicClient client;
 
-    public static final long DEFAULT_CACHE_SIZE = 500;
+    public static final long DEFAULT_CACHE_SIZE = 750;
 
-    public static final long DEFAULT_CACHE_MILLIS = 500;
-    public static final long DEFAULT_INITIAL_DELAY = 10;
+    public static final long DEFAULT_CACHE_MILLIS = 800;
+    public static final long DEFAULT_INITIAL_DELAY = 50;
 
-    private RDFFormat format = RDFFormat.NQUADS;
+    protected RDFFormat format = RDFFormat.NQUADS;
 
-    private long cacheSize;
+    protected long cacheSize;
 
-    private long cacheMillis;
+    protected long cacheMillis;
 
-    private Date lastCacheAccess = new Date();
+    protected Date lastCacheAccess = new Date();
 
     /**
      * constructor
      *
      * @param client
      */
-    public WriteCacheTimerTask(MarkLogicClient client) {
+    public TripleCache(MarkLogicClient client) {
         super();
         this.client = client;
         this.cache = new LinkedHashModel();
@@ -76,7 +80,7 @@ public class WriteCacheTimerTask extends TimerTask {
         this.cacheMillis = DEFAULT_CACHE_MILLIS;
     }
 
-    public WriteCacheTimerTask(MarkLogicClient client, long cacheSize) {
+    public TripleCache(MarkLogicClient client, long cacheSize) {
         super();
         this.client = client;
         this.cache = new LinkedHashModel();
@@ -126,35 +130,42 @@ public class WriteCacheTimerTask extends TimerTask {
     @Override
     public synchronized void run(){
         Date now = new Date();
-        if ( this.cache.size() > this.cacheSize - 1 || (this.cache.size() > 0 && now.getTime() - this.lastCacheAccess.getTime() > this.cacheMillis)) {
+        if ( !cache.isEmpty() &&
+                ((cache.size() > cacheSize - 1) || (now.getTime() - lastCacheAccess.getTime() > cacheMillis))) {
             try {
                 flush();
-            } catch ( MarkLogicSesameException| InterruptedException e) {
-                // cannot throw exception in runnable run(), best we log it
-                log.warn("Exception thrown in other thread, when running writeCacheTimerTask.");
-                log.warn(e.toString(),e );
+            } catch (RepositoryException e) {
+                e.printStackTrace();
+            } catch (MalformedQueryException e) {
+                e.printStackTrace();
+            } catch (UpdateExecutionException e) {
+                e.printStackTrace();
+            } catch (IOException e) {
+                e.printStackTrace();
             }
         }
     }
 
-    /**
-     * flushes the cache, writing triples as graph
-     *
-     * @throws MarkLogicSesameException
-     */
-    private void flush() throws MarkLogicSesameException, InterruptedException {
-        log.debug("flushing write cache:" + this.cache.size());
-        try {
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            Rio.write(this.cache, out, this.format);
-            this.client.sendAdd(new ByteArrayInputStream(out.toByteArray()), null, this.format);
-            this.lastCacheAccess = new Date();
-            this.cache.clear();
-        } catch (RDFHandlerException | RDFParseException e) {
-            log.info(e.getLocalizedMessage());
-            throw new MarkLogicSesameException(e);
-        }
-    }
+//    /**
+//     * flushes the cache, writing triples as graph
+//     *
+//     * @throws MarkLogicSesameException
+//     */
+//    private void flush1() throws MarkLogicSesameException, InterruptedException {
+//        log.debug("flushing write cache:" + this.cache.size());
+//        try {
+//            ByteArrayOutputStream out = new ByteArrayOutputStream();
+//            Rio.write(this.cache, out, this.format);
+//            this.client.sendAdd(new ByteArrayInputStream(out.toByteArray()), null, this.format);
+//            this.lastCacheAccess = new Date();
+//            this.cache.clear();
+//        } catch (RDFHandlerException | RDFParseException e) {
+//            log.info(e.getLocalizedMessage());
+//            throw new MarkLogicSesameException(e);
+//        }
+//    }
+
+    protected abstract void flush() throws RepositoryException, MalformedQueryException, UpdateExecutionException, IOException;
 
     /**min
      * forces the cache to flush if there is anything in it
@@ -162,12 +173,19 @@ public class WriteCacheTimerTask extends TimerTask {
      * @throws MarkLogicSesameException
      */
     public void forceRun() throws MarkLogicSesameException {
-        try {
-            if( this.cache.size() > 0) {
+        log.debug(String.valueOf(cache.size()));
+        if( !cache.isEmpty()) {
+            try {
                 flush();
+            } catch (RepositoryException e) {
+                e.printStackTrace();
+            } catch (MalformedQueryException e) {
+                e.printStackTrace();
+            } catch (UpdateExecutionException e) {
+                e.printStackTrace();
+            } catch (IOException e) {
+                e.printStackTrace();
             }
-        } catch (InterruptedException e) {
-            throw new MarkLogicSesameException(e);
         }
     }
 
@@ -180,8 +198,8 @@ public class WriteCacheTimerTask extends TimerTask {
      * @param contexts
      */
     public synchronized void add(Resource subject, URI predicate, Value object, Resource... contexts) throws MarkLogicSesameException {
-        this.cache.add(subject,predicate,object,contexts);
-        if(this.cache.size() > this.cacheSize){
+        cache.add(subject,predicate,object,contexts);
+        if( cache.size() > cacheSize - 1){
             forceRun();
         }
     }

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/client/TripleDeleteCache.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/client/TripleDeleteCache.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015-2016 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.marklogic.semantics.sesame.client;
+
+import com.marklogic.semantics.sesame.MarkLogicSesameException;
+import org.openrdf.model.*;
+import org.openrdf.query.MalformedQueryException;
+import org.openrdf.query.UpdateExecutionException;
+import org.openrdf.query.parser.sparql.SPARQLUtil;
+import org.openrdf.repository.RepositoryException;
+import org.openrdf.repository.sparql.query.SPARQLQueryBindingSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Created by jfuller on 11/2/16.
+ */
+public class TripleDeleteCache extends TripleCache {
+
+    private static final Logger log = LoggerFactory.getLogger(TripleDeleteCache.class);
+
+    public TripleDeleteCache(MarkLogicClient client) {
+        super(client);
+    }
+
+    public TripleDeleteCache(MarkLogicClient client, long cacheSize) {
+        super(client, cacheSize);
+    }
+    /**
+     * flushes the cache, writing triples as graph
+     *
+     * @throws MarkLogicSesameException
+     */
+    
+    protected synchronized void flush() throws RepositoryException, MalformedQueryException, UpdateExecutionException, IOException {
+        if (cache.isEmpty()) { return; }
+        StringBuffer entireQuery = new StringBuffer();
+        SPARQLQueryBindingSet bindingSet = new SPARQLQueryBindingSet();
+
+        for (Namespace ns :cache.getNamespaces()){
+            entireQuery.append("PREFIX "+ns.getPrefix()+": <"+ns.getName()+">. ");
+        }
+        entireQuery.append("DELETE DATA { ");
+
+        Set<Resource> distinctCtx = new HashSet<Resource>();
+        for (Resource context :cache.contexts()) {
+            distinctCtx.add(context);
+        }
+
+        for (Resource ctx : distinctCtx) {
+               if (ctx != null) {
+                   entireQuery.append(" GRAPH <" + ctx + "> { ");
+               }
+                for (Statement stmt : cache.filter(null, null, null, ctx)) {
+                    entireQuery.append("<" + stmt.getSubject().stringValue() + "> ");
+                    entireQuery.append("<" + stmt.getPredicate().stringValue() + "> ");
+                    Value object=stmt.getObject();
+                    if (object instanceof Literal) {
+                        Literal lit = (Literal) object;
+                        entireQuery.append("\"");
+                        entireQuery.append(SPARQLUtil.encodeString(lit.getLabel()));
+                        entireQuery.append("\"");
+                        if(null == lit.getLanguage()) {
+                            entireQuery.append("^^<" + lit.getDatatype().stringValue() + ">");
+                        }else{
+                            entireQuery.append("@" + lit.getLanguage().toString());
+                        }
+                    } else {
+                        entireQuery.append("<" + object.stringValue() + "> ");
+                    }
+                    entireQuery.append(".");
+                }
+                if (ctx != null) {
+                    entireQuery.append(" }");
+                }
+        }
+
+        entireQuery.append("} ");
+        log.info(entireQuery.toString());
+        client.sendUpdateQuery(entireQuery.toString(),bindingSet,false,null);
+        lastCacheAccess = new Date();
+        //log.info("success writing cache: {}",String.valueOf(cache.size()));
+        cache.clear();
+
+    }
+
+
+}

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/client/TripleWriteCache.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/client/TripleWriteCache.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2015-2016 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.marklogic.semantics.sesame.client;
+
+import com.marklogic.client.impl.SPARQLBindingImpl;
+import com.marklogic.client.semantics.SPARQLBinding;
+import com.marklogic.client.semantics.SPARQLQueryDefinition;
+import com.marklogic.semantics.sesame.MarkLogicSesameException;
+import org.openrdf.model.*;
+import org.openrdf.query.MalformedQueryException;
+import org.openrdf.query.UpdateExecutionException;
+import org.openrdf.query.parser.sparql.SPARQLUtil;
+import org.openrdf.repository.RepositoryException;
+import org.openrdf.repository.sparql.query.SPARQLQueryBindingSet;
+import org.openrdf.rio.RDFHandlerException;
+import org.openrdf.rio.RDFParseException;
+import org.openrdf.rio.Rio;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Created by jfuller on 11/2/16.
+ */
+public class TripleWriteCache extends TripleCache {
+
+    private static final Logger log = LoggerFactory.getLogger(TripleWriteCache.class);
+
+    public TripleWriteCache(MarkLogicClient client) {
+        super(client);
+    }
+
+    public TripleWriteCache(MarkLogicClient client, long cacheSize) {
+        super(client, cacheSize);
+    }
+    /**
+     * flushes the cache, writing triples as graph
+     *
+     * @throws MarkLogicSesameException
+     */
+
+    protected synchronized void flush() throws RepositoryException, MalformedQueryException, UpdateExecutionException, IOException {
+        if (cache.isEmpty()) { return; }
+        StringBuffer entireQuery = new StringBuffer();
+        SPARQLQueryBindingSet bindingSet = new SPARQLQueryBindingSet();
+
+        for (Namespace ns :cache.getNamespaces()){
+            entireQuery.append("PREFIX "+ns.getPrefix()+": <"+ns.getName()+">. ");
+        }
+        entireQuery.append("INSERT DATA { ");
+
+        Set<Resource> distinctCtx = new HashSet<Resource>();
+        for (Resource context :cache.contexts()) {
+            distinctCtx.add(context);
+        }
+
+        for (Resource ctx : distinctCtx) {
+               if (ctx != null) {
+                   entireQuery.append(" GRAPH <" + ctx + "> { ");
+               }
+                for (Statement stmt : cache.filter(null, null, null, ctx)) {
+                    entireQuery.append("<" + stmt.getSubject().stringValue() + "> ");
+                    entireQuery.append("<" + stmt.getPredicate().stringValue() + "> ");
+                    Value object=stmt.getObject();
+                    if (object instanceof Literal) {
+                        Literal lit = (Literal) object;
+                        entireQuery.append("\"");
+                        entireQuery.append(SPARQLUtil.encodeString(lit.getLabel()));
+                        entireQuery.append("\"");
+                        if(null == lit.getLanguage()) {
+                            entireQuery.append("^^<" + lit.getDatatype().stringValue() + ">");
+                        }else{
+                            entireQuery.append("@" + lit.getLanguage().toString());
+                        }
+                    } else {
+                        entireQuery.append("<" + object.stringValue() + "> ");
+                    }
+                    entireQuery.append(".");
+                }
+                if (ctx != null) {
+                    entireQuery.append(" }");
+                }
+        }
+
+        entireQuery.append("} ");
+        log.debug(entireQuery.toString());
+        client.sendUpdateQuery(entireQuery.toString(),bindingSet,false,null);
+        lastCacheAccess = new Date();
+        log.debug("success writing cache: {}",String.valueOf(cache.size()));
+        cache.clear();
+
+    }
+
+
+}

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicBooleanQuery.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicBooleanQuery.java
@@ -23,6 +23,7 @@ import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.semantics.GraphPermissions;
 import com.marklogic.client.query.QueryDefinition;
 import com.marklogic.client.semantics.SPARQLRuleset;
+import com.marklogic.semantics.sesame.MarkLogicSesameException;
 import com.marklogic.semantics.sesame.client.MarkLogicClient;
 import org.openrdf.query.BooleanQuery;
 import org.openrdf.query.MalformedQueryException;
@@ -64,6 +65,7 @@ public class MarkLogicBooleanQuery extends MarkLogicQuery implements BooleanQuer
     @Override
     public boolean evaluate() throws QueryEvaluationException {
         try {
+            sync();
             return getMarkLogicClient().sendBooleanQuery(getQueryString(), getBindings(), getIncludeInferred(),getBaseURI());
         }catch (RepositoryException e) {
             throw new QueryEvaluationException(e.getMessage(), e);

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicGraphQuery.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicGraphQuery.java
@@ -67,6 +67,7 @@ public class MarkLogicGraphQuery extends MarkLogicQuery implements GraphQuery,Ma
     public GraphQueryResult evaluate()
             throws QueryEvaluationException {
         try {
+            sync();
             return getMarkLogicClient().sendGraphQuery(getQueryString(),getBindings(),getIncludeInferred(),getBaseURI());
         } catch (IOException e) {
             throw new QueryEvaluationException(e);

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicQuery.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicQuery.java
@@ -22,6 +22,7 @@ package com.marklogic.semantics.sesame.query;
 import com.marklogic.client.query.QueryDefinition;
 import com.marklogic.client.semantics.GraphPermissions;
 import com.marklogic.client.semantics.SPARQLRuleset;
+import com.marklogic.semantics.sesame.MarkLogicSesameException;
 import com.marklogic.semantics.sesame.client.MarkLogicClient;
 import com.marklogic.semantics.sesame.client.MarkLogicClientDependent;
 import org.openrdf.model.Value;
@@ -297,5 +298,9 @@ public class MarkLogicQuery extends AbstractQuery implements Query,MarkLogicClie
     @Override
     public GraphPermissions getGraphPerms() {
         return getMarkLogicClient().getGraphPerms();
+    }
+
+    protected void sync() throws MarkLogicSesameException {
+        getMarkLogicClient().sync();
     }
 }

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicTupleQuery.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicTupleQuery.java
@@ -23,6 +23,7 @@ import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.semantics.GraphPermissions;
 import com.marklogic.client.query.QueryDefinition;
 import com.marklogic.client.semantics.SPARQLRuleset;
+import com.marklogic.semantics.sesame.MarkLogicSesameException;
 import com.marklogic.semantics.sesame.client.MarkLogicClient;
 import org.openrdf.query.*;
 import org.openrdf.repository.RepositoryException;
@@ -78,6 +79,7 @@ public class MarkLogicTupleQuery extends MarkLogicQuery implements TupleQuery,Ma
     public TupleQueryResult evaluate(long start, long pageLength)
             throws QueryEvaluationException {
         try {
+            sync();
             return getMarkLogicClient().sendTupleQuery(getQueryString(), getBindings(), start, pageLength, getIncludeInferred(), getBaseURI());
         }catch (RepositoryException e) {
             throw new QueryEvaluationException(e.getMessage(), e);
@@ -97,7 +99,11 @@ public class MarkLogicTupleQuery extends MarkLogicQuery implements TupleQuery,Ma
      */
     @Override
     public void evaluate(TupleQueryResultHandler resultHandler) throws QueryEvaluationException, TupleQueryResultHandlerException {
-        TupleQueryResult queryResult = evaluate();
+        try {
+            sync();
+        } catch (MarkLogicSesameException e) {
+            e.printStackTrace();
+        }        TupleQueryResult queryResult = evaluate();
         if(queryResult.hasNext()) {
             QueryResults.report(queryResult, resultHandler);
         }

--- a/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicUpdateQuery.java
+++ b/marklogic-sesame/src/main/java/com/marklogic/semantics/sesame/query/MarkLogicUpdateQuery.java
@@ -24,6 +24,7 @@ import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.semantics.GraphPermissions;
 import com.marklogic.client.query.QueryDefinition;
 import com.marklogic.client.semantics.SPARQLRuleset;
+import com.marklogic.semantics.sesame.MarkLogicSesameException;
 import com.marklogic.semantics.sesame.client.MarkLogicClient;
 import org.openrdf.query.MalformedQueryException;
 import org.openrdf.query.Update;
@@ -64,6 +65,7 @@ public class MarkLogicUpdateQuery extends MarkLogicQuery implements Update,MarkL
     @Override
     public void execute() throws UpdateExecutionException {
         try {
+            sync();
             getMarkLogicClient().sendUpdateQuery(getQueryString(), getBindings(), getIncludeInferred(), getBaseURI());
         }catch(ForbiddenUserException | FailedRequestException e){
             throw new UpdateExecutionException(e);

--- a/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/MarkLogicRepositoryCacheTest.java
+++ b/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/MarkLogicRepositoryCacheTest.java
@@ -28,6 +28,7 @@ import org.openrdf.IsolationLevels;
 import org.openrdf.model.*;
 import org.openrdf.model.impl.StatementImpl;
 import org.openrdf.model.impl.URIImpl;
+import org.openrdf.repository.RepositoryResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +43,7 @@ import static org.junit.Assert.assertEquals;
  * @author James Fuller
  */
 // @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class MarkLogicRepositoryWriteCacheTest extends SesameTestBase {
+public class MarkLogicRepositoryCacheTest extends SesameTestBase {
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -161,5 +162,8 @@ public class MarkLogicRepositoryWriteCacheTest extends SesameTestBase {
         conn.add(bulkInsert, graph);
         conn.commit();
         assertEquals(100000L, conn.size());
+//        RepositoryResult stmts = conn.getStatements(null,null,null,false,graph);
+//        conn.remove(stmts);
+//        assertEquals(0L, conn.size());
     }
 }

--- a/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnectionTest.java
+++ b/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/MarkLogicRepositoryConnectionTest.java
@@ -1152,10 +1152,10 @@ conn.sync();
         conn.add(fei, lname, feilname);
         conn.add(fei, age, feiage);
         //conn.add(fei, age, invalidIntegerLiteral);
-
-        logger.info("lang:{}", conn.hasStatement(vf.createStatement(fei, lname, vf.createLiteral("Ling", "en")), false));
+        logger.info("lang:{}", conn.hasStatement(vf.createStatement(fei, lname, vf.createLiteral("Ling", "zh")), false));
+        logger.info("size:{}", conn.size());
         Assert.assertFalse("The lang tag of lname is not en", conn.hasStatement(vf.createStatement(fei, lname, vf.createLiteral("Ling", "en")), false));
-        Assert.assertTrue("The lang tag of lname is zh", conn.hasStatement(vf.createStatement(fei, lname, vf.createLiteral("Ling", "zh")), false));
+        Assert.assertTrue("The lang tag of lname is zh", conn.hasStatement(vf.createStatement(fei, lname, feilname), false));
         Assert.assertFalse(conn.isEmpty());
     }
 

--- a/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/MultiThreadedPersistenceTest.java
+++ b/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/MultiThreadedPersistenceTest.java
@@ -95,7 +95,7 @@ public class MultiThreadedPersistenceTest extends SesameTestBase {
             }
         }
 
-        public void persist(List<Entity> entities){
+        public void persist(List<Entity> entities) {
 
             MarkLogicRepositoryConnection connection = null;
             try {
@@ -107,6 +107,12 @@ public class MultiThreadedPersistenceTest extends SesameTestBase {
                 //print to sysout as thread exceptions are not propagated up to main thread
                 e.printStackTrace();
                 throw new RuntimeException(e);
+            }finally {
+                try {
+                    connection.close();
+                } catch (RepositoryException e) {
+                    e.printStackTrace();
+                }
             }
         }
 

--- a/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/config/MarkLogicRepositoryManagerTest.java
+++ b/marklogic-sesame/src/test/java/com/marklogic/semantics/sesame/config/MarkLogicRepositoryManagerTest.java
@@ -86,7 +86,7 @@ public class MarkLogicRepositoryManagerTest {
 
     @Ignore
     @Test
-    // will not work due to RemoteRepositoryManager usage of HTTPRepository
+    // requires a Sesame server to be running eg. RemoteRepositoryManager uses HTTPRepository
     public void testRemoteManager() throws Exception {
         RepositoryManager manager;
         manager = new RemoteRepositoryManager("http://localhost:8080/openrdf-sesame");


### PR DESCRIPTION
Refactored write cache (using marklogic-jena as inspiration, thx @grechaw )

Implemented delete cache but have not enabled - we want to get a clear signal first with new write cache first before enabling.

Enhanced and enabled tests for multithreading/commit.


